### PR TITLE
Fix warnings due to missing save_post explicit number of args

### DIFF
--- a/p2p_ui_main.php
+++ b/p2p_ui_main.php
@@ -151,8 +151,8 @@ function p2pui_save_connection_meta($post_id, $post) {
     }
 	return;
 }
-add_action('save_post', 'p2pui_save_connection_meta');	
-add_action('save_post', 'p2pui_save_datatype_meta');
+add_action('save_post', 'p2pui_save_connection_meta', 10, 2);	
+add_action('save_post', 'p2pui_save_datatype_meta', 10, 2);
 
 function p2pui_setup_connections() {	//registers connection-types from each connection-type post
 	$get_post_args = array(


### PR DESCRIPTION
PHP returns warnings for a missing second (`$post`) argument to the `save_post` callback functions - changing the add_action declaration for compatibility.
